### PR TITLE
Add the documentation for s3WriteGzip and s3StorageClass

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -2255,9 +2255,6 @@ tpacketv3NumThreads=2</pre>
             <td>
               S3 Region to send data to
             </td>
-            <td>
-              &nbsp;
-            </td>
           </tr>
           <tr>
             <td id="s3buckt">
@@ -2313,6 +2310,34 @@ tpacketv3NumThreads=2</pre>
             </td>
             <td>
               Should traffic be compressed before sending
+            </td>
+          </tr>
+          <tr>
+            <td id="s3writegzip">
+              s3WriteGzip
+              <span class="fa fa-link small copy-link cursor-copy"
+                onclick="copyLink(this, 'settings')">
+              </span>
+            </td>
+            <td>
+              FALSE
+            </td>
+            <td>
+              Should the PCAP files be stored on S3 in gzipped form
+            </td>
+          </tr>
+          <tr>
+            <td id="s3storageclass">
+              s3StorageClass
+              <span class="fa fa-link small copy-link cursor-copy"
+                onclick="copyLink(this, 'settings')">
+              </span>
+            </td>
+            <td>
+              STANDARD
+            </td>
+            <td>
+              The S3 storage class to use&emdash;this has pricing implications
             </td>
           </tr>
           <tr>

--- a/settings.html
+++ b/settings.html
@@ -2323,7 +2323,7 @@ tpacketv3NumThreads=2</pre>
               FALSE
             </td>
             <td>
-              (since 2.1) Should the PCAP files be stored on S3 in gzipped form
+              (Since 2.1) Should the PCAP files be stored on S3 in gzipped form
             </td>
           </tr>
           <tr>
@@ -2337,7 +2337,7 @@ tpacketv3NumThreads=2</pre>
               STANDARD
             </td>
             <td>
-              (since 2.1) The S3 storage class to use&emdash;this has pricing implications
+              (Since 2.1) The S3 storage class to use&emdash;this has pricing implications
             </td>
           </tr>
           <tr>

--- a/settings.html
+++ b/settings.html
@@ -2323,7 +2323,7 @@ tpacketv3NumThreads=2</pre>
               FALSE
             </td>
             <td>
-              Should the PCAP files be stored on S3 in gzipped form
+              (since 2.1) Should the PCAP files be stored on S3 in gzipped form
             </td>
           </tr>
           <tr>
@@ -2337,7 +2337,7 @@ tpacketv3NumThreads=2</pre>
               STANDARD
             </td>
             <td>
-              The S3 storage class to use&emdash;this has pricing implications
+              (since 2.1) The S3 storage class to use&emdash;this has pricing implications
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
This documents the adding of two new configuration variables for the `writer-s3` plugin that is part of PR https://github.com/aol/moloch/pull/1185


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
