### PR TITLE
Add a note about the default for s3AccessKeyId...

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -2278,7 +2278,7 @@ tpacketv3NumThreads=2</pre>
               </span>
             </td>
             <td>
-              none
+              (Since 2.1) Obtained from the EC2 IAM Role.
             </td>
             <td>
               &nbsp;
@@ -2292,7 +2292,7 @@ tpacketv3NumThreads=2</pre>
               </span>
             </td>
             <td>
-              none
+              (Since 2.1) Obtained from the EC2 IAM Role.
             </td>
             <td>
               &nbsp;


### PR DESCRIPTION
Just adds a note about the new defaults for the s3AccessKeyId and s3SecretAccessKey.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
