### PR TITLE
Add documentation for new Custom logging options

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -1452,7 +1452,7 @@ title: Settings
               :date :username %1b[1m:method%1b[0m %1b[33m:url%1b[0m :status :res[content-length] bytes :response-time ms
             </td>
             <td>
-              (Since 2.3.0) Set the log record format -- this uses Express Morgan. The string is URL Encoded and so uses %xx
+              (Since 2.3) Set the log record format -- this uses Express Morgan. The string is URL Encoded and so uses %xx
               to escape special characters.
               See the Morgan documentation for the <a href="https://github.com/expressjs/morgan">list of keywords</a>.
             </td>
@@ -1468,7 +1468,7 @@ title: Settings
               EMPTY
             </td>
             <td>
-                (Since 2.3.0) This is a semi-colon seperated list of URL paths which should <em>not</em> be logged.
+                (Since 2.3) This is a semi-colon seperated list of URL paths which should <em>not</em> be logged.
                 Seeting this to /eshealth.json will suppress logging of all calls to that endpoint.
             </td>
           </tr>

--- a/settings.html
+++ b/settings.html
@@ -1427,6 +1427,52 @@ title: Settings
         </thead>
         <tbody>
           <tr>
+            <td id="accessLogFile">
+              accessLogFile
+              <span class="fa fa-link small copy-link cursor-copy"
+                onclick="copyLink(this, 'settings')">
+              </span>
+            </td>
+            <td>
+              EMPTY
+            </td>
+            <td>
+                If left empty, then the viewer will log to stdout. It can be set to a filename and then logging will
+                be directed there.
+            </td>
+          </tr>
+          <tr>
+            <td id="accessLogFormat">
+              accessLogFormat
+              <span class="fa fa-link small copy-link cursor-copy"
+                onclick="copyLink(this, 'settings')">
+              </span>
+            </td>
+            <td>
+              :date :username %1b[1m:method%1b[0m %1b[33m:url%1b[0m :status :res[content-length] bytes :response-time ms
+            </td>
+            <td>
+              (Since 2.3.0) Set the log record format -- this uses Express Morgan. The string is URL Encoded and so uses %xx
+              to escape special characters.
+              See the Morgan documentation for the <a href="https://github.com/expressjs/morgan">list of keywords</a>.
+            </td>
+          </tr>
+          <tr>
+            <td id="accessLogSuppressPaths">
+              accessLogSuppressPaths
+              <span class="fa fa-link small copy-link cursor-copy"
+                onclick="copyLink(this, 'settings')">
+              </span>
+            </td>
+            <td>
+              EMPTY
+            </td>
+            <td>
+                (Since 2.3.0) This is a semi-colon seperated list of URL paths which should <em>not</em> be logged.
+                Seeting this to /eshealth.json will suppress logging of all calls to that endpoint.
+            </td>
+          </tr>
+          <tr>
             <td id="autogenerateid">
               autoGenerateId
               <span class="fa fa-link small copy-link cursor-copy"
@@ -1933,6 +1979,22 @@ title: Settings
             </td>
           </tr>
           <tr>
+            <td id="queryallindices">
+              queryAllIndices
+              <span class="fa fa-link small copy-link cursor-copy"
+                onclick="copyLink(this, 'settings')">
+              </span>
+            </td>
+            <td>
+              FALSE for viewer, TRUE for multiviewer
+            </td>
+            <td>
+              (Since 1.5.0) Always query all indices instead of trying to
+              calculate which ones. Use this if searching across that use
+              different rotateIndex values.
+            </td>
+          </tr>
+          <tr>
             <td id="saveunknownpackets">
               saveUnknownPackets
               <span class="fa fa-link small copy-link cursor-copy"
@@ -2044,6 +2106,32 @@ title: Settings
             </td>
           </tr>
           <tr>
+            <td id="uploadcommand">uploadCommand<span class="fa fa-link small copy-link cursor-copy" onclick="copyLink(this, 'settings')"></span></td>
+            <td>
+              EMPTY
+            </td>
+            <td>
+              If set uploads from the UI are allowed.  An upload saves the file and runs capture on it, so its better to just run capture instead of using upload if you can.
+              Example setting would be <code>/data/moloch/bin/moloch-capture --copy -n {NODE} -r {TMPFILE} -c {CONFIG} {TAGS}</code>.  <br>
+              The following templated values will be filled in for you:
+              <ul>
+                <li>NODE - The node name of the viewer that received the upload</li>
+                <li>TMPFILE - The tmp file name uploaded to</li>
+                <li>CONFIG - The config file path used to start viewer</li>
+                <li>TAGS - The tags set with the upload</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td id="uploadfilesizelimit">uploadFileSizeLimit<span class="fa fa-link small copy-link cursor-copy" onclick="copyLink(this, 'settings')"></span></td>
+            <td>
+              EMPTY
+            </td>
+            <td>
+              (Since 2.0) If set, the max size of pcap files that can be uploaded from the UI
+            </td>
+          </tr>
+          <tr>
             <td id="userselasticsearch">
               usersElasticsearch
               <span class="fa fa-link small copy-link cursor-copy"
@@ -2086,48 +2174,6 @@ title: Settings
             </td>
             <td>
               Autocomplete field values in the search expression.
-            </td>
-          </tr>
-          <tr>
-            <td id="queryallindices">
-              queryAllIndices
-              <span class="fa fa-link small copy-link cursor-copy"
-                onclick="copyLink(this, 'settings')">
-              </span>
-            </td>
-            <td>
-              FALSE for viewer, TRUE for multiviewer
-            </td>
-            <td>
-              (Since 1.5.0) Always query all indices instead of trying to
-              calculate which ones. Use this if searching across that use
-              different rotateIndex values.
-            </td>
-          </tr>
-          <tr>
-          <tr>
-            <td id="uploadcommand">uploadCommand<span class="fa fa-link small copy-link cursor-copy" onclick="copyLink(this, 'settings')"></span></td>
-            <td>
-              EMPTY
-            </td>
-            <td>
-              If set uploads from the UI are allowed.  An upload saves the file and runs capture on it, so its better to just run capture instead of using upload if you can.
-              Example setting would be <code>/data/moloch/bin/moloch-capture --copy -n {NODE} -r {TMPFILE} -c {CONFIG} {TAGS}</code>.  <br> 
-              The following templated values will be filled in for you:
-              <ul>
-                <li>NODE - The node name of the viewer that received the upload</li>
-                <li>TMPFILE - The tmp file name uploaded to</li>
-                <li>CONFIG - The config file path used to start viewer</li>
-                <li>TAGS - The tags set with the upload</li>
-              </ul>
-            </td>
-          </tr>
-            <td id="uploadfilesizelimit">uploadFileSizeLimit<span class="fa fa-link small copy-link cursor-copy" onclick="copyLink(this, 'settings')"></span></td>
-            <td>
-              EMPTY
-            </td>
-            <td>
-              (Since 2.0) If set, the max size of pcap files that can be uploaded from the UI
             </td>
           </tr>
         </tbody>
@@ -4073,7 +4119,7 @@ suricataAlertFile=/nids/suricata/eve.json</code></pre>
         </span>
       </h2>
       <p>
-        TCP Health Check plugin enables 
+        TCP Health Check plugin enables
         the capture module to listen on
         a specific TCP port and immediately
         close accepted connections. This is useful


### PR DESCRIPTION
This adds the documentation for the two new custom logging parameters that were added to 2.3. It also documents the other accessLog parameter that was missing. It also sorts a few of the Advanced settings into alphabetical order.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
